### PR TITLE
Standardize decorator parameter usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 ]
 
 name = "easytl"
-version = "v0.3.0"
+version = "v0.3.1"
 authors = [
   { name="Bikatr7", email="Bikatr7@proton.me" },
 ]

--- a/src/easytl/deepl_service.py
+++ b/src/easytl/deepl_service.py
@@ -167,12 +167,7 @@ class DeepLService:
 
         try:
 
-            if(DeepLService._decorator_to_use is None):
-                return DeepLService._translator.translate_text(**params)
-            
-            else:
-                decorated_function = DeepLService._decorator_to_use(DeepLService._translate_text)
-                return decorated_function(**params)
+            return DeepLService._translator.translate_text(**params)
             
         except Exception as _e:
             raise _e
@@ -203,14 +198,10 @@ class DeepLService:
             params = DeepLService._prepare_translation_parameters(text)
 
             try:
-                if(DeepLService._decorator_to_use is None):
-                    loop = asyncio.get_running_loop()
-                    return await loop.run_in_executor(None, lambda: DeepLService._translator.translate_text(**params))
-                
-                else:
-                    decorated_function = DeepLService._decorator_to_use(DeepLService._translate_text_async)
-                    return await decorated_function(**params)
-                
+
+                loop = asyncio.get_running_loop()
+                return await loop.run_in_executor(None, lambda: DeepLService._translator.translate_text(**params))
+                                
             except Exception as _e:
                 raise _e
 

--- a/src/easytl/deepl_service.py
+++ b/src/easytl/deepl_service.py
@@ -7,9 +7,13 @@ import typing
 import asyncio
 import time
 
+
 ## third-party libraries
 from deepl.translator import Translator
 
+import deepl
+
+## custom modules
 from .util import _convert_iterable_to_str
 from .decorators import _async_logging_decorator, _sync_logging_decorator
 from .classes import Language, SplitSentences, Formality, GlossaryInfo, TextResult
@@ -89,6 +93,13 @@ class DeepLService:
         DeepLService._decorator_to_use = decorator
 
         DeepLService._log_directory = logging_directory
+
+        ## if a decorator is used, we want to disable retries, otherwise set it to the default value which is 5
+        if(DeepLService._decorator_to_use is not None):
+            deepl.http_client.max_network_retries = 0
+
+        else:
+            deepl.http_client.max_network_retries = 5
 
         if(semaphore is not None):
             DeepLService._semaphore_value = semaphore

--- a/src/easytl/deepl_service.py
+++ b/src/easytl/deepl_service.py
@@ -160,6 +160,9 @@ class DeepLService:
 
         """
 
+
+        ## decorators need to be applied outside of the function, for reasons detailed in easytl.py
+
         if(DeepLService._rate_limit_delay is not None):
             time.sleep(DeepLService._rate_limit_delay)
 
@@ -189,6 +192,8 @@ class DeepLService:
         translation (TextResult or list of TextResult) : The translation result.
 
         """
+
+        ## decorators need to be applied outside of the function, for reasons detailed in easytl.py
 
         async with DeepLService._semaphore:
 

--- a/src/easytl/easytl.py
+++ b/src/easytl/easytl.py
@@ -767,12 +767,10 @@ class EasyTL:
 
         This function is not for use for real-time translation, nor for generating multiple translation candidates. Another function may be implemented for this given demand.
 
-        OpenAI has it's backoff retrying disabled by EasyTL, in favor of the user implementing their own retrying mechanism via the decorator.
-
         Parameters:
         text (string or iterable) : The text to translate.
         override_previous_settings (bool) : Whether to override the previous settings that were used during the last call to an OpenAI translation function.
-        decorator (callable or None) : The decorator to use when translating. Typically for exponential backoff retrying.
+        decorator (callable or None) : The decorator to use when translating. Typically for exponential backoff retrying. If this is None, OpenAI will retry the request twice if it fails.
         logging_directory (string or None) : The directory to log to. If None, no logging is done. This'll append the text result and some function information to a file in the specified directory. File is created if it doesn't exist.
         response_type (literal["text", "raw", "json"]) : The type of response to return. 'text' returns the translated text, 'raw' returns the raw response, a ChatCompletion object, 'json' returns a json-parseable string.
         translation_delay (float or None) : If text is an iterable, the delay between each translation. Default is none. This is more important for asynchronous translations where a semaphore alone may not be sufficient.
@@ -876,12 +874,10 @@ class EasyTL:
 
         This function is not for use for real-time translation, nor for generating multiple translation candidates. Another function may be implemented for this given demand.
 
-        OpenAI has it's backoff retrying disabled by EasyTL.
-
         Parameters:
         text (string or iterable) : The text to translate.
         override_previous_settings (bool) : Whether to override the previous settings that were used during the last call to an OpenAI translation function.
-        decorator (callable or None) : The decorator to use when translating. Typically for exponential backoff retrying.
+        decorator (callable or None) : The decorator to use when translating. Typically for exponential backoff retrying. If this is None, OpenAI will retry the request twice if it fails.
         logging_directory (string or None) : The directory to log to. If None, no logging is done. This'll append the text result and some function information to a file in the specified directory. File is created if it doesn't exist.
         response_type (literal["text", "raw", "json"]) : The type of response to return. 'text' returns the translated text, 'raw' returns the raw response, a ChatCompletion object, 'json' returns a json-parseable string.
         semaphore (int) : The number of concurrent requests to make. Default is 5.

--- a/src/easytl/easytl.py
+++ b/src/easytl/easytl.py
@@ -361,15 +361,13 @@ class EasyTL:
 
         This function assumes that the API key has already been set.
 
-        DeepL has backoff retrying implemented by default.
-
         Due to how DeepL's API works, the translation delay and semaphore are not as important as they are for other services. As they process iterables directly.
 
         Parameters:
         text (string or iterable) : The text to translate.
         target_lang (string or Language) : The target language to translate to.
         override_previous_settings (bool) : Whether to override the previous settings that were used during the last call to a DeepL translation function.
-        decorator (callable or None) : The decorator to use when translating. Typically for exponential backoff retrying.
+        decorator (callable or None) : The decorator to use when translating. Typically for exponential backoff retrying. If this parameter is None, DeepL will retry your request 5 times before failing. Otherwise, the given decorator will be used.
         logging_directory (string or None) : The directory to log to. If None, no logging is done. This'll append the text result and some function information to a file in the specified directory. File is created if it doesn't exist.
         response_type (literal["text", "raw"]) : The type of response to return. 'text' returns the translated text, 'raw' returns the raw response, a TextResult object.
         translation_delay (float or None) : If text is an iterable, the delay between each translation. Default is none. This is more important for asynchronous translations where a semaphore alone may not be sufficient.
@@ -472,7 +470,7 @@ class EasyTL:
         text (string or iterable) : The text to translate.
         target_lang (string or Language) : The target language to translate to.
         override_previous_settings (bool) : Whether to override the previous settings that were used during the last call to a DeepL translation function.
-        decorator (callable or None) : The decorator to use when translating. Typically for exponential backoff retrying.
+        decorator (callable or None) : The decorator to use when translating. Typically for exponential backoff retrying. If this parameter is None, DeepL will retry your request 5 times before failing. Otherwise, the given decorator will be used.
         logging_directory (string or None) : The directory to log to. If None, no logging is done. This'll append the text result and some function information to a file in the specified directory. File is created if it doesn't exist.
         response_type (literal["text", "raw"]) : The type of response to return. 'text' returns the translated text, 'raw' returns the raw response, a TextResult object.
         semaphore (int) : The number of concurrent requests to make. Default is 30.

--- a/src/easytl/googletl_service.py
+++ b/src/easytl/googletl_service.py
@@ -170,6 +170,8 @@ class GoogleTLService:
 
         """
 
+        ## decorators need to be applied outside of the function for reasons detailed in easytl.py
+
         if(GoogleTLService._rate_limit_delay is not None):
             time.sleep(GoogleTLService._rate_limit_delay)
 
@@ -177,13 +179,8 @@ class GoogleTLService:
 
         try:
 
-            if(GoogleTLService._decorator_to_use is None):
-                return GoogleTLService._translator.translate(**params)
-            
-            else:
-                decorated_function = GoogleTLService._decorator_to_use(GoogleTLService._translate_text)
-                return decorated_function(**params)
-            
+            return GoogleTLService._translator.translate(**params)
+                        
         except Exception as _e:
             raise _e
         
@@ -205,6 +202,8 @@ class GoogleTLService:
 
         """
 
+        ## decorators need to be applied outside of the function for reasons detailed in easytl.py
+
         async with GoogleTLService._semaphore:
 
             if(GoogleTLService._rate_limit_delay is not None):
@@ -213,13 +212,9 @@ class GoogleTLService:
             params = GoogleTLService._prepare_translation_parameters(text)
 
             try:
-                if(GoogleTLService._decorator_to_use is None):
-                    loop = asyncio.get_running_loop()
-                    return await loop.run_in_executor(None, lambda: GoogleTLService._translator.translate(**params))
                 
-                else:
-                    decorated_function = GoogleTLService._decorator_to_use(GoogleTLService._translate_text_async)
-                    return await decorated_function(**params)
+                loop = asyncio.get_running_loop()
+                return await loop.run_in_executor(None, lambda: GoogleTLService._translator.translate(**params))
                 
             except Exception as _e:
                 raise _e

--- a/src/easytl/openai_service.py
+++ b/src/easytl/openai_service.py
@@ -36,8 +36,8 @@ class OpenAIService:
     _semaphore_value:int = 5
     _semaphore:asyncio.Semaphore = asyncio.Semaphore(_semaphore_value)
 
-    _sync_client = OpenAI(max_retries=0, api_key="DummyKey")
-    _async_client = AsyncOpenAI(max_retries=0, api_key="DummyKey")
+    _sync_client = OpenAI(api_key="DummyKey")
+    _async_client = AsyncOpenAI(api_key="DummyKey")
 
     _rate_limit_delay:float | None = None
 
@@ -109,6 +109,13 @@ class OpenAIService:
 
             OpenAIService._json_mode = json_mode
 
+            ## if a decorator is used, we want to disable retries, otherwise set it to the default value which is 2
+            if(OpenAIService._decorator_to_use is not None):
+                OpenAIService._sync_client.max_retries = 0
+                OpenAIService._async_client.max_retries = 0
+            else:
+                OpenAIService._sync_client.max_retries = 2
+                OpenAIService._async_client.max_retries = 2
             
             if(semaphore is not None):
                 OpenAIService._semaphore_value = semaphore

--- a/src/easytl/version.py
+++ b/src/easytl/version.py
@@ -2,4 +2,4 @@
 ## Use of this source code is governed by an GNU Lesser General Public License v2.1
 ## license that can be found in the LICENSE file.
 
-VERSION = "0.3.0"
+VERSION = "0.3.1"

--- a/tests/passing.py
+++ b/tests/passing.py
@@ -74,18 +74,18 @@ async def main():
 
     print("------------------------------------------------Text response------------------------------------------------")
 
-    print(EasyTL.deepl_translate(text="Hello, world!", target_lang="DE", logging_directory=logging_directory))
-    print(await EasyTL.deepl_translate_async(text="Hello, world!", target_lang="DE", logging_directory=logging_directory))
+    print(EasyTL.deepl_translate(text="Hello, world!", target_lang="DE", logging_directory=logging_directory, decorator=decorator))
+    print(await EasyTL.deepl_translate_async(text="Hello, world!", target_lang="DE", logging_directory=logging_directory,decorator=decorator))
 
-    print(EasyTL.deepl_translate("Hello, world!", target_lang="DE", response_type="raw", logging_directory=logging_directory).text) # type: ignore
-    result = await EasyTL.deepl_translate_async("Hello, world!", target_lang="DE", response_type="raw", logging_directory=logging_directory)
+    print(EasyTL.deepl_translate("Hello, world!", target_lang="DE", response_type="raw", logging_directory=logging_directory, decorator=decorator).text) # type: ignore
+    result = await EasyTL.deepl_translate_async("Hello, world!", target_lang="DE", response_type="raw", logging_directory=logging_directory, decorator=decorator)
 
     print(result.text) # type: ignore
 
     print("------------------------------------------------Raw response------------------------------------------------")
 
-    results = EasyTL.deepl_translate(text=["Hello, world!", "Goodbye, world!"], target_lang="DE", response_type="raw", logging_directory=logging_directory)
-    async_results = await EasyTL.deepl_translate_async(text=["Hello, world!", "Goodbye, world!"], target_lang="DE", response_type="raw", logging_directory=logging_directory)
+    results = EasyTL.deepl_translate(text=["Hello, world!", "Goodbye, world!"], target_lang="DE", response_type="raw", logging_directory=logging_directory, decorator=decorator)
+    async_results = await EasyTL.deepl_translate_async(text=["Hello, world!", "Goodbye, world!"], target_lang="DE", response_type="raw", logging_directory=logging_directory, decorator=decorator)
 
     for result in results: # type: ignore
         print(result.text) # type: ignore
@@ -103,18 +103,18 @@ async def main():
 
     print("------------------------------------------------Text response------------------------------------------------")
 
-    print(EasyTL.googletl_translate("Hello, world!", target_lang="de", logging_directory=logging_directory))
-    print(await EasyTL.googletl_translate_async("Hello, world!", target_lang="de", logging_directory=logging_directory))
+    print(EasyTL.googletl_translate("Hello, world!", target_lang="de", logging_directory=logging_directory, decorator=decorator))
+    print(await EasyTL.googletl_translate_async("Hello, world!", target_lang="de", logging_directory=logging_directory, decorator=decorator))
 
-    print(EasyTL.googletl_translate("Hello, world!", target_lang="de", response_type="raw", logging_directory=logging_directory)["translatedText"]) # type: ignore
-    result = await EasyTL.googletl_translate_async("Hello, world!", target_lang="de", response_type="raw", logging_directory=logging_directory)
+    print(EasyTL.googletl_translate("Hello, world!", target_lang="de", response_type="raw", logging_directory=logging_directory, decorator=decorator)["translatedText"]) # type: ignore
+    result = await EasyTL.googletl_translate_async("Hello, world!", target_lang="de", response_type="raw", logging_directory=logging_directory, decorator=decorator)
 
     print(result["translatedText"]) # type: ignore
 
     print("------------------------------------------------Raw response------------------------------------------------")
 
-    results = EasyTL.googletl_translate(text=["Hello, world!", "Goodbye, world!"], target_lang="de", response_type="raw", logging_directory=logging_directory)
-    async_results = await EasyTL.googletl_translate_async(text=["Hello, world!", "Goodbye, world!"], target_lang="de", response_type="raw", logging_directory=logging_directory)
+    results = EasyTL.googletl_translate(text=["Hello, world!", "Goodbye, world!"], target_lang="de", response_type="raw", logging_directory=logging_directory, decorator=decorator)
+    async_results = await EasyTL.googletl_translate_async(text=["Hello, world!", "Goodbye, world!"], target_lang="de", response_type="raw", logging_directory=logging_directory, decorator=decorator)
 
     for result in results: # type: ignore
         print(result["translatedText"]) # type: ignore


### PR DESCRIPTION
Fixed Issues with DeepL and Google Translate user provided decorators not applying properly
DeepL and OpenAI now only have their retry disabled if the user provides a decorator
push to easytl v0.3.1